### PR TITLE
Prevent launching node.js script file in working directory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,8 @@ function writeShim_ (from, to, prog, args, cb) {
   // @IF EXIST "%~dp0\node.exe" (
   //   "%~dp0\node.exe" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
   // ) ELSE (
+  //   SETLOCAL
+  //   SET PATHEXT=%PATHEXT:;.JS;=;%
   //   node "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
   // )
   var cmd
@@ -106,6 +108,8 @@ function writeShim_ (from, to, prog, args, cb) {
     cmd = "@IF EXIST " + longProg + " (\r\n"
         + "  " + longProg + " " + args + " " + target + " %*\r\n"
         + ") ELSE (\r\n"
+        + "  @SETLOCAL\r\n"
+        + "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
         + "  " + prog + " " + args + " " + target + " %*\r\n"
         + ")"
   } else {

--- a/test/basic.js
+++ b/test/basic.js
@@ -50,6 +50,8 @@ test('env shebang', function (t) {
             "@IF EXIST \"%~dp0\\node.exe\" (\r"+
             "\n  \"%~dp0\\node.exe\"  \"%~dp0\\from.env\" %*\r"+
             "\n) ELSE (\r"+
+            "\n  @SETLOCAL\r"+
+            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r"+
             "\n  node  \"%~dp0\\from.env\" %*\r"+
             "\n)")
     t.end()
@@ -86,6 +88,8 @@ test('env shebang with args', function (t) {
             "@IF EXIST \"%~dp0\\node.exe\" (\r"+
             "\n  \"%~dp0\\node.exe\"  --expose_gc \"%~dp0\\from.env.args\" %*\r"+
             "\n) ELSE (\r"+
+            "\n  @SETLOCAL\r"+
+            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r"+
             "\n  node  --expose_gc \"%~dp0\\from.env.args\" %*\r"+
             "\n)")
     t.end()
@@ -123,6 +127,8 @@ test('explicit shebang', function (t) {
             "@IF EXIST \"%~dp0\\/usr/bin/sh.exe\" (\r" +
             "\n  \"%~dp0\\/usr/bin/sh.exe\"  \"%~dp0\\from.sh\" %*\r" +
             "\n) ELSE (\r" +
+            "\n  @SETLOCAL\r"+
+            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r"+
             "\n  /usr/bin/sh  \"%~dp0\\from.sh\" %*\r" +
             "\n)")
     t.end()
@@ -160,6 +166,8 @@ test('explicit shebang with args', function (t) {
             "@IF EXIST \"%~dp0\\/usr/bin/sh.exe\" (\r" +
             "\n  \"%~dp0\\/usr/bin/sh.exe\"  -x \"%~dp0\\from.sh.args\" %*\r" +
             "\n) ELSE (\r" +
+            "\n  @SETLOCAL\r"+
+            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r"+
             "\n  /usr/bin/sh  -x \"%~dp0\\from.sh.args\" %*\r" +
             "\n)")
     t.end()


### PR DESCRIPTION
The PATHEXT environment variable on Windows often includes .JS, which means running "node" can try to execute a file named "node.js" in the current working directory. As npm-installed executable scripts are often executed in directories containing .js files, this is not unlikely.

This change works around it by locally stripping the .JS extension from the PATHEXT environment variable.
