### PR TITLE
Wrap octal literals into string at fs.chmod calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.nyc_output
 
 pids
 logs
@@ -13,4 +14,5 @@ results
 
 npm-debug.log
 
+coverage
 node_modules

--- a/index.js
+++ b/index.js
@@ -163,8 +163,8 @@ function writeShim_ (from, to, prog, args, cb) {
 
 function chmodShim (to, cb) {
   var then = times(2, cb, cb)
-  fs.chmod(to, 0755, then)
-  fs.chmod(to + ".cmd", 0755, then)
+  fs.chmod(to, 0o755, then)
+  fs.chmod(to + ".cmd", 0o755, then)
 }
 
 function times(n, ok, cb) {

--- a/index.js
+++ b/index.js
@@ -163,8 +163,8 @@ function writeShim_ (from, to, prog, args, cb) {
 
 function chmodShim (to, cb) {
   var then = times(2, cb, cb)
-  fs.chmod(to, 0o755, then)
-  fs.chmod(to + ".cmd", 0o755, then)
+  fs.chmod(to, "0755", then)
+  fs.chmod(to + ".cmd", "0755", then)
 }
 
 function times(n, ok, cb) {


### PR DESCRIPTION
Hello!
Your module uses [deprecated](https://github.com/babel/babel/issues/2569) syntax of octal literals.
Since the module is a dependency for Yarn, such syntax causes a Nyc coverage report crash. It appears the reason for [crash](https://travis-ci.org/octet-stream/twi/jobs/234779543) is that Nyc is trying to open and parse yarn-cli.js using babel-register.
Could you please approve this patch?