### PR TITLE
fix `Invalid number` error

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,8 +163,8 @@ function writeShim_ (from, to, prog, args, cb) {
 
 function chmodShim (to, cb) {
   var then = times(2, cb, cb)
-  fs.chmod(to, 0755, then)
-  fs.chmod(to + ".cmd", 0755, then)
+  fs.chmod(to, "0755", then)
+  fs.chmod(to + ".cmd", "0755", then)
 }
 
 function times(n, ok, cb) {


### PR DESCRIPTION
Using octals without `o` is now deprecated and results in compile
errors when using the latest Babel.