### PR TITLE
Fix arguments with parenthesis causing an error on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,22 +92,28 @@ function writeShim_ (from, to, prog, args, cb) {
     shTarget = "\"$basedir/" + shTarget + "\""
   }
 
+  // @SETLOCAL
+  //
   // @IF EXIST "%~dp0\node.exe" (
-  //   "%~dp0\node.exe" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
+  //   @SET "_prog=%~dp0\node.exe"
   // ) ELSE (
-  //   SETLOCAL
-  //   SET PATHEXT=%PATHEXT:;.JS;=;%
-  //   node "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
+  //   @SET "_prog=node"
+  //   @SET PATHEXT=%PATHEXT:;.JS;=;%
   // )
+  //
+  // "%_prog%" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
   var cmd
   if (longProg) {
-    cmd = "@IF EXIST " + longProg + " (\r\n"
-        + "  " + longProg + " " + args + " " + target + " %*\r\n"
+    cmd = "@SETLOCAL\r\n"
+        + "\r\n"
+        + "@IF EXIST " + longProg + " (\r\n"
+        + "  @SET \"_prog=" + longProg.replace(/(^")|("$)/g, '') + "\"\r\n"
         + ") ELSE (\r\n"
-        + "  @SETLOCAL\r\n"
+        + "  @SET \"_prog=" + prog.replace(/(^")|("$)/g, '') + "\"\r\n"
         + "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
-        + "  " + prog + " " + args + " " + target + " %*\r\n"
-        + ")"
+        + ")\r\n"
+        + "\r\n"
+        +  "\"%_prog%\" " + args + " " + target + " %*\r\n"
   } else {
     cmd = "@" + prog + " " + args + " " + target + " %*\r\n"
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -30,30 +30,34 @@ test('env shebang', function (t) {
     console.error('%j', fs.readFileSync(to + '.cmd', 'utf8'))
 
     t.equal(fs.readFileSync(to, 'utf8'),
-            "#!/bin/sh"+
-            "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")"+
-            "\n"+
-            "\ncase `uname` in"+
-            "\n    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;"+
-            "\nesac"+
-            "\n"+
-            "\nif [ -x \"$basedir/node\" ]; then"+
-            "\n  \"$basedir/node\"  \"$basedir/from.env\" \"$@\""+
-            "\n  ret=$?"+
-            "\nelse "+
-            "\n  node  \"$basedir/from.env\" \"$@\""+
-            "\n  ret=$?"+
-            "\nfi"+
-            "\nexit $ret"+
+            "#!/bin/sh" +
+            "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")" +
+            "\n" +
+            "\ncase `uname` in" +
+            "\n    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;" +
+            "\nesac" +
+            "\n" +
+            "\nif [ -x \"$basedir/node\" ]; then" +
+            "\n  \"$basedir/node\"  \"$basedir/from.env\" \"$@\"" +
+            "\n  ret=$?" +
+            "\nelse " +
+            "\n  node  \"$basedir/from.env\" \"$@\"" +
+            "\n  ret=$?" +
+            "\nfi" +
+            "\nexit $ret" +
             "\n")
     t.equal(fs.readFileSync(to + '.cmd', 'utf8'),
-            "@IF EXIST \"%~dp0\\node.exe\" (\r"+
-            "\n  \"%~dp0\\node.exe\"  \"%~dp0\\from.env\" %*\r"+
-            "\n) ELSE (\r"+
-            "\n  @SETLOCAL\r"+
-            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r"+
-            "\n  node  \"%~dp0\\from.env\" %*\r"+
-            "\n)")
+            "@SETLOCAL\r" +
+            "\n\r" +
+            "\n@IF EXIST \"%~dp0\\node.exe\" (\r" +
+            "\n  @SET \"_prog=%~dp0\\node.exe\"\r" +
+            "\n) ELSE (\r" +
+            "\n  @SET \"_prog=node\"\r" +
+            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r" +
+            "\n)\r" +
+            "\n\r" +
+            "\n\"%_prog%\"  \"%~dp0\\from.env\" %*\r" +
+            "\n")
     t.end()
   })
 })
@@ -68,30 +72,34 @@ test('env shebang with args', function (t) {
     console.error('%j', fs.readFileSync(to + '.cmd', 'utf8'))
 
     t.equal(fs.readFileSync(to, 'utf8'),
-            "#!/bin/sh"+
-            "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")"+
-            "\n"+
-            "\ncase `uname` in"+
-            "\n    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;"+
-            "\nesac"+
-            "\n"+
-            "\nif [ -x \"$basedir/node\" ]; then"+
-            "\n  \"$basedir/node\"  --expose_gc \"$basedir/from.env.args\" \"$@\""+
-            "\n  ret=$?"+
-            "\nelse "+
-            "\n  node  --expose_gc \"$basedir/from.env.args\" \"$@\""+
-            "\n  ret=$?"+
-            "\nfi"+
-            "\nexit $ret"+
+            "#!/bin/sh" +
+            "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")" +
+            "\n" +
+            "\ncase `uname` in" +
+            "\n    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;" +
+            "\nesac" +
+            "\n" +
+            "\nif [ -x \"$basedir/node\" ]; then" +
+            "\n  \"$basedir/node\"  --expose_gc \"$basedir/from.env.args\" \"$@\"" +
+            "\n  ret=$?" +
+            "\nelse " +
+            "\n  node  --expose_gc \"$basedir/from.env.args\" \"$@\"" +
+            "\n  ret=$?" +
+            "\nfi" +
+            "\nexit $ret" +
             "\n")
     t.equal(fs.readFileSync(to + '.cmd', 'utf8'),
-            "@IF EXIST \"%~dp0\\node.exe\" (\r"+
-            "\n  \"%~dp0\\node.exe\"  --expose_gc \"%~dp0\\from.env.args\" %*\r"+
-            "\n) ELSE (\r"+
-            "\n  @SETLOCAL\r"+
-            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r"+
-            "\n  node  --expose_gc \"%~dp0\\from.env.args\" %*\r"+
-            "\n)")
+            "@SETLOCAL\r" +
+            "\n\r" +
+            "\n@IF EXIST \"%~dp0\\node.exe\" (\r" +
+            "\n  @SET \"_prog=%~dp0\\node.exe\"\r" +
+            "\n) ELSE (\r" +
+            "\n  @SET \"_prog=node\"\r" +
+            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r" +
+            "\n)\r" +
+            "\n\r" +
+            "\n\"%_prog%\"  --expose_gc \"%~dp0\\from.env.args\" %*\r" +
+            "\n")
     t.end()
   })
 })
@@ -124,13 +132,17 @@ test('explicit shebang', function (t) {
             "\n")
 
     t.equal(fs.readFileSync(to + '.cmd', 'utf8'),
-            "@IF EXIST \"%~dp0\\/usr/bin/sh.exe\" (\r" +
-            "\n  \"%~dp0\\/usr/bin/sh.exe\"  \"%~dp0\\from.sh\" %*\r" +
+            "@SETLOCAL\r" +
+            "\n\r" +
+            "\n@IF EXIST \"%~dp0\\/usr/bin/sh.exe\" (\r" +
+            "\n  @SET \"_prog=%~dp0\\/usr/bin/sh.exe\"\r" +
             "\n) ELSE (\r" +
-            "\n  @SETLOCAL\r"+
-            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r"+
-            "\n  /usr/bin/sh  \"%~dp0\\from.sh\" %*\r" +
-            "\n)")
+            "\n  @SET \"_prog=/usr/bin/sh\"\r" +
+            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r" +
+            "\n)\r" +
+            "\n\r" +
+            "\n\"%_prog%\"  \"%~dp0\\from.sh\" %*\r" +
+            "\n")
     t.end()
   })
 })
@@ -163,13 +175,17 @@ test('explicit shebang with args', function (t) {
             "\n")
 
     t.equal(fs.readFileSync(to + '.cmd', 'utf8'),
-            "@IF EXIST \"%~dp0\\/usr/bin/sh.exe\" (\r" +
-            "\n  \"%~dp0\\/usr/bin/sh.exe\"  -x \"%~dp0\\from.sh.args\" %*\r" +
+            "@SETLOCAL\r" +
+            "\n\r" +
+            "\n@IF EXIST \"%~dp0\\/usr/bin/sh.exe\" (\r" +
+            "\n  @SET \"_prog=%~dp0\\/usr/bin/sh.exe\"\r" +
             "\n) ELSE (\r" +
-            "\n  @SETLOCAL\r"+
-            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r"+
-            "\n  /usr/bin/sh  -x \"%~dp0\\from.sh.args\" %*\r" +
-            "\n)")
+            "\n  @SET \"_prog=/usr/bin/sh\"\r" +
+            "\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r" +
+            "\n)\r" +
+            "\n\r" +
+            "\n\"%_prog%\"  -x \"%~dp0\\from.sh.args\" %*\r" +
+            "\n")
     t.end()
   })
 })


### PR DESCRIPTION
Because %* is expanded before anything, any arguments with parenthesis will make the .cmd fail with the following message:
\"" was unexpected at this time

This might actually be a security vulnerability because with the rightly crafted arguments, one would possibly execute arbirtrary commands,
even if the arguments were properly escaped.
Read https://gist.github.com/satazor/4e21543e5cd380032c2b6b38c3700223 for a more detailed explanation.

To solve this, %* was moved out of the condition.