### PR TITLE
Fix octal number 0755 mistake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.8"
+  - "lts/*"
+  - "node"
+  - "4"

--- a/index.js
+++ b/index.js
@@ -163,8 +163,8 @@ function writeShim_ (from, to, prog, args, cb) {
 
 function chmodShim (to, cb) {
   var then = times(2, cb, cb)
-  fs.chmod(to, 0755, then)
-  fs.chmod(to + ".cmd", 0755, then)
+  fs.chmod(to, 0o755, then)
+  fs.chmod(to + ".cmd", 0o755, then)
 }
 
 function times(n, ok, cb) {


### PR DESCRIPTION
I noticed that an octal number with `0` prefix was used. This could cause a SyntaxError in strict mode [as explained on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Converting_mistakes_into_errors). 
And I'm actually suffering with it because some important libraries I use are depending on `cmd-shim` and this piece of code is throwing errors. So I hope you can make a patch update very soon.

### Addition
CI is reporting errors. According to the log, the test fails on Node 0.10, in which I believe ES2015 is not supported. Note that the testing tool `tap` [states a runtime requirement of Node >= 4](https://github.com/tapjs/node-tap/blob/master/package.json#L11), so I think the CI config should also get an update after so long a time.