### PR TITLE
Update all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "graceful-fs": "^4.1.2",
-    "mkdirp": "~0.5.0"
+    "graceful-fs": "^4.1.11",
+    "mkdirp": "~0.5.1"
   },
   "devDependencies": {
-    "tap": "~0.4.11",
-    "rimraf": "~2.2.8"
+    "tap": "~12.0.1",
+    "rimraf": "~2.6.2"
   }
 }


### PR DESCRIPTION
The original intention was to only update minimap, as `npm audit`
complains about this dependency being vulnerable to a regexp attach, and
that warning got a little annoying.

The minimap dependency is an indirect one, via tap, so let's update tap.
This also gives us nice coloring of the test output!

While at it, simply update all dependencies, not just tap.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>