### PR TITLE
Use strict-mode compatible octal literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,8 +163,8 @@ function writeShim_ (from, to, prog, args, cb) {
 
 function chmodShim (to, cb) {
   var then = times(2, cb, cb)
-  fs.chmod(to, 0755, then)
-  fs.chmod(to + ".cmd", 0755, then)
+  fs.chmod(to, 0o755, then)
+  fs.chmod(to + ".cmd", 0o755, then)
 }
 
 function times(n, ok, cb) {


### PR DESCRIPTION
If you're doing unsupported things like trying to bundle npm's CLI, and are using a bundler that assumes ES6 modules for all source files, then the deprecated octal literals used here are problematic. This PR replaces the deprecated form with the modern octal literal form.