### PR TITLE
fix #35: always set $basedir for win32 bash

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,16 +129,14 @@ function writeShim_ (from, to, prog, args, cb) {
   // exit $ret
 
   var sh = "#!/bin/sh\n"
+      + "basedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")\n"
+      + "\n"
+      + "case `uname` in\n"
+      + "    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;\n"
+      + "esac\n"
+      + "\n"
 
   if (shLongProg) {
-    sh = sh
-        + "basedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")\n"
-        + "\n"
-        + "case `uname` in\n"
-        + "    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;\n"
-        + "esac\n"
-        + "\n"
-
     sh = sh
        + "if [ -x "+shLongProg+" ]; then\n"
        + "  " + shLongProg + " " + args + " " + shTarget + " \"$@\"\n"


### PR DESCRIPTION
Re: #35 

basedir is always required:

```js
  if (!prog) {
    prog = "\"%~dp0\\" + target + "\""
    shProg = "\"$basedir/" + shTarget + "\""
    args = ""
    target = ""
    shTarget = ""
  } else {
    longProg = "\"%~dp0\\" + prog + ".exe\""
    shLongProg = "\"$basedir/" + prog + "\""
    target = "\"%~dp0\\" + target + "\""
    shTarget = "\"$basedir/" + shTarget + "\""
  }
```

and so so it should always be set:

```diff
diff --git a/index.js b/index.js
index 9f22e10..0437df9 100644
--- a/index.js
+++ b/index.js
@@ -129,16 +129,14 @@ function writeShim_ (from, to, prog, args, cb) {
   // exit $ret

   var sh = "#!/bin/sh\n"
+      + "basedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")\n"
+      + "\n"
+      + "case `uname` in\n"
+      + "    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;\n"
+      + "esac\n"
+      + "\n"

   if (shLongProg) {
-    sh = sh
-        + "basedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")\n"
-        + "\n"
-        + "case `uname` in\n"
-        + "    *CYGWIN*) basedir=`cygpath -w \"$basedir\"`;;\n"
-        + "esac\n"
-        + "\n"
-
     sh = sh
        + "if [ -x "+shLongProg+" ]; then\n"
```

Alternatively, we could explore using `$(dirname $0)`, but this seems to be the smallest possible change.