### PR TITLE
Fix quotes on windows cmd shims

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,19 +101,21 @@ function writeShim_ (from, to, prog, args, variables, cb) {
     shTarget = "\"$basedir/" + shTarget + "\""
   }
 
-  // @SETLOCAL
-  // @CALL :find_dp0
+  // SETLOCAL
+  // CALL :find_dp0
   //
-  // @IF EXIST "%dp0%\node.exe" (
-  //   @SET "_prog=%dp0%\node.exe"
+  // SET _maybeQuote="
+  // IF EXIST "%dp0%\node.exe" (
+  //   SET "_prog=%dp0%\node.exe"
   // ) ELSE (
-  //   @SET "_prog=node"
-  //   @SET PATHEXT=%PATHEXT:;.JS;=;%
+  //   SET "_prog=node"
+  //   SET _maybeQuote=
+  //   SET PATHEXT=%PATHEXT:;.JS;=;%
   // )
   //
-  // "%_prog%" "%dp0%\.\node_modules\npm\bin\npm-cli.js" %*
-  // @ENDLOCAL
-  // @EXIT /b %errorlevel%
+  // %_maybeQuote%%_prog%%_maybeQuote% "%dp0%\.\node_modules\npm\bin\npm-cli.js" %*
+  // ENDLOCAL
+  // EXIT /b %errorlevel%
   //
   // :find_dp0
   // SET dp0=%~dp0
@@ -137,14 +139,16 @@ function writeShim_ (from, to, prog, args, variables, cb) {
     cmd = head
         + variableDeclarationsAsBatch
         + "\r\n"
+	+ "SET _maybeQuote=\"\r\n"
         + "IF EXIST " + longProg + " (\r\n"
         + "  SET \"_prog=" + longProg.replace(/(^")|("$)/g, '') + "\"\r\n"
         + ") ELSE (\r\n"
+	+ "  SET _maybeQuote=\r\n"
         + "  SET \"_prog=" + prog.replace(/(^")|("$)/g, '') + "\"\r\n"
         + "  SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
         + ")\r\n"
         + "\r\n"
-        +  "\"%_prog%\" " + args + " " + target + " %*\r\n"
+        +  "%_maybeQuote%%_prog%%_maybeQuote% " + args + " " + target + " %*\r\n"
         + foot
   } else {
     cmd = head + prog + " " + args + " " + target + " %*\r\n" + foot

--- a/tap-snapshots/test-basic.js-TAP.test.js
+++ b/tap-snapshots/test-basic.js-TAP.test.js
@@ -10,14 +10,16 @@ exports[`test/basic.js TAP env shebang > cmd 1`] = `
 SETLOCAL\\r
 CALL :find_dp0\\r
 \\r
+SET _maybeQuote="\\r
 IF EXIST "%dp0%\\node.exe" (\\r
   SET "_prog=%dp0%\\node.exe"\\r
 ) ELSE (\\r
+  SET _maybeQuote=\\r
   SET "_prog=node"\\r
   SET PATHEXT=%PATHEXT:;.JS;=;%\\r
 )\\r
 \\r
-"%_prog%"  "%dp0%\\from.env" %*\\r
+%_maybeQuote%%_prog%%_maybeQuote%  "%dp0%\\from.env" %*\\r
 ENDLOCAL\\r
 EXIT /b %errorlevel%\\r
 :find_dp0\\r
@@ -72,14 +74,16 @@ exports[`test/basic.js TAP env shebang with args > cmd 1`] = `
 SETLOCAL\\r
 CALL :find_dp0\\r
 \\r
+SET _maybeQuote="\\r
 IF EXIST "%dp0%\\node.exe" (\\r
   SET "_prog=%dp0%\\node.exe"\\r
 ) ELSE (\\r
+  SET _maybeQuote=\\r
   SET "_prog=node"\\r
   SET PATHEXT=%PATHEXT:;.JS;=;%\\r
 )\\r
 \\r
-"%_prog%" --expose_gc "%dp0%\\from.env.args" %*\\r
+%_maybeQuote%%_prog%%_maybeQuote% --expose_gc "%dp0%\\from.env.args" %*\\r
 ENDLOCAL\\r
 EXIT /b %errorlevel%\\r
 :find_dp0\\r
@@ -135,14 +139,16 @@ SETLOCAL\\r
 CALL :find_dp0\\r
 @SET NODE_PATH=./lib:%NODE_PATH%\\r
 \\r
+SET _maybeQuote="\\r
 IF EXIST "%dp0%\\node.exe" (\\r
   SET "_prog=%dp0%\\node.exe"\\r
 ) ELSE (\\r
+  SET _maybeQuote=\\r
   SET "_prog=node"\\r
   SET PATHEXT=%PATHEXT:;.JS;=;%\\r
 )\\r
 \\r
-"%_prog%"  "%dp0%\\from.env.variables" %*\\r
+%_maybeQuote%%_prog%%_maybeQuote%  "%dp0%\\from.env.variables" %*\\r
 ENDLOCAL\\r
 EXIT /b %errorlevel%\\r
 :find_dp0\\r
@@ -197,14 +203,16 @@ exports[`test/basic.js TAP explicit shebang > cmd 1`] = `
 SETLOCAL\\r
 CALL :find_dp0\\r
 \\r
+SET _maybeQuote="\\r
 IF EXIST "%dp0%\\/usr/bin/sh.exe" (\\r
   SET "_prog=%dp0%\\/usr/bin/sh.exe"\\r
 ) ELSE (\\r
+  SET _maybeQuote=\\r
   SET "_prog=/usr/bin/sh"\\r
   SET PATHEXT=%PATHEXT:;.JS;=;%\\r
 )\\r
 \\r
-"%_prog%"  "%dp0%\\from.sh" %*\\r
+%_maybeQuote%%_prog%%_maybeQuote%  "%dp0%\\from.sh" %*\\r
 ENDLOCAL\\r
 EXIT /b %errorlevel%\\r
 :find_dp0\\r
@@ -259,14 +267,16 @@ exports[`test/basic.js TAP explicit shebang with args > cmd 1`] = `
 SETLOCAL\\r
 CALL :find_dp0\\r
 \\r
+SET _maybeQuote="\\r
 IF EXIST "%dp0%\\/usr/bin/sh.exe" (\\r
   SET "_prog=%dp0%\\/usr/bin/sh.exe"\\r
 ) ELSE (\\r
+  SET _maybeQuote=\\r
   SET "_prog=/usr/bin/sh"\\r
   SET PATHEXT=%PATHEXT:;.JS;=;%\\r
 )\\r
 \\r
-"%_prog%" -x "%dp0%\\from.sh.args" %*\\r
+%_maybeQuote%%_prog%%_maybeQuote% -x "%dp0%\\from.sh.args" %*\\r
 ENDLOCAL\\r
 EXIT /b %errorlevel%\\r
 :find_dp0\\r


### PR DESCRIPTION
Resolves #41 by only using quotes around the node executable when a non-local node binary is used.