### PR TITLE
fix: restructure .cmd to yield correct errorlevel

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,13 +101,13 @@ const writeShim_ = (from, to, prog, args, variables) => {
   //
   // Subroutine trick to fix https://github.com/npm/cmd-shim/issues/10
   const head = '@ECHO off\r\n' +
-    'SETLOCAL\r\n' +
-    'CALL :find_dp0\r\n'
-  const foot = 'ENDLOCAL\r\n' +
-    'EXIT /b %errorlevel%\r\n' +
+    'GOTO start\r\n' +
     ':find_dp0\r\n' +
     'SET dp0=%~dp0\r\n' +
-    'EXIT /b\r\n'
+    'EXIT /b\r\n' +
+    ':start\r\n' +
+    'SETLOCAL\r\n' +
+    'CALL :find_dp0\r\n'
 
   let cmd
   if (longProg) {
@@ -125,9 +125,8 @@ const writeShim_ = (from, to, prog, args, variables) => {
         + ')\r\n'
         + '\r\n'
         +  `"%_prog%" ${args} ${target} %*\r\n`
-        + foot
   } else {
-    cmd = `${head}${prog} ${args} ${target} %*\r\n${foot}`
+    cmd = `${head}${prog} ${args} ${target} %*\r\n`
   }
 
   // #!/bin/sh

--- a/tap-snapshots/test-basic.js-TAP.test.js
+++ b/tap-snapshots/test-basic.js-TAP.test.js
@@ -7,6 +7,11 @@
 'use strict'
 exports[`test/basic.js TAP env shebang > cmd 1`] = `
 @ECHO off\\r
+GOTO start\\r
+:find_dp0\\r
+SET dp0=%~dp0\\r
+EXIT /b\\r
+:start\\r
 SETLOCAL\\r
 CALL :find_dp0\\r
 \\r
@@ -18,11 +23,6 @@ IF EXIST "%dp0%\\node.exe" (\\r
 )\\r
 \\r
 "%_prog%"  "%dp0%\\from.env" %*\\r
-ENDLOCAL\\r
-EXIT /b %errorlevel%\\r
-:find_dp0\\r
-SET dp0=%~dp0\\r
-EXIT /b\\r
 
 `
 
@@ -79,6 +79,11 @@ exit $ret
 
 exports[`test/basic.js TAP env shebang with args > cmd 1`] = `
 @ECHO off\\r
+GOTO start\\r
+:find_dp0\\r
+SET dp0=%~dp0\\r
+EXIT /b\\r
+:start\\r
 SETLOCAL\\r
 CALL :find_dp0\\r
 \\r
@@ -90,11 +95,6 @@ IF EXIST "%dp0%\\node.exe" (\\r
 )\\r
 \\r
 "%_prog%" --expose_gc "%dp0%\\from.env.args" %*\\r
-ENDLOCAL\\r
-EXIT /b %errorlevel%\\r
-:find_dp0\\r
-SET dp0=%~dp0\\r
-EXIT /b\\r
 
 `
 
@@ -151,6 +151,11 @@ exit $ret
 
 exports[`test/basic.js TAP env shebang with variables > cmd 1`] = `
 @ECHO off\\r
+GOTO start\\r
+:find_dp0\\r
+SET dp0=%~dp0\\r
+EXIT /b\\r
+:start\\r
 SETLOCAL\\r
 CALL :find_dp0\\r
 @SET NODE_PATH=./lib:%NODE_PATH%\\r
@@ -163,11 +168,6 @@ IF EXIST "%dp0%\\node.exe" (\\r
 )\\r
 \\r
 "%_prog%"  "%dp0%\\from.env.variables" %*\\r
-ENDLOCAL\\r
-EXIT /b %errorlevel%\\r
-:find_dp0\\r
-SET dp0=%~dp0\\r
-EXIT /b\\r
 
 `
 
@@ -224,6 +224,11 @@ exit $ret
 
 exports[`test/basic.js TAP explicit shebang > cmd 1`] = `
 @ECHO off\\r
+GOTO start\\r
+:find_dp0\\r
+SET dp0=%~dp0\\r
+EXIT /b\\r
+:start\\r
 SETLOCAL\\r
 CALL :find_dp0\\r
 \\r
@@ -235,11 +240,6 @@ IF EXIST "%dp0%\\/usr/bin/sh.exe" (\\r
 )\\r
 \\r
 "%_prog%"  "%dp0%\\from.sh" %*\\r
-ENDLOCAL\\r
-EXIT /b %errorlevel%\\r
-:find_dp0\\r
-SET dp0=%~dp0\\r
-EXIT /b\\r
 
 `
 
@@ -296,6 +296,11 @@ exit $ret
 
 exports[`test/basic.js TAP explicit shebang with args > cmd 1`] = `
 @ECHO off\\r
+GOTO start\\r
+:find_dp0\\r
+SET dp0=%~dp0\\r
+EXIT /b\\r
+:start\\r
 SETLOCAL\\r
 CALL :find_dp0\\r
 \\r
@@ -307,11 +312,6 @@ IF EXIST "%dp0%\\/usr/bin/sh.exe" (\\r
 )\\r
 \\r
 "%_prog%" -x "%dp0%\\from.sh.args" %*\\r
-ENDLOCAL\\r
-EXIT /b %errorlevel%\\r
-:find_dp0\\r
-SET dp0=%~dp0\\r
-EXIT /b\\r
 
 `
 
@@ -368,14 +368,14 @@ exit $ret
 
 exports[`test/basic.js TAP if exists (it does exist) > cmd 1`] = `
 @ECHO off\\r
-SETLOCAL\\r
-CALL :find_dp0\\r
-"%dp0%\\from.exe"   %*\\r
-ENDLOCAL\\r
-EXIT /b %errorlevel%\\r
+GOTO start\\r
 :find_dp0\\r
 SET dp0=%~dp0\\r
 EXIT /b\\r
+:start\\r
+SETLOCAL\\r
+CALL :find_dp0\\r
+"%dp0%\\from.exe"   %*\\r
 
 `
 
@@ -414,14 +414,14 @@ exit $?
 
 exports[`test/basic.js TAP just proceed if reading fails > cmd 1`] = `
 @ECHO off\\r
-SETLOCAL\\r
-CALL :find_dp0\\r
-"%dp0%\\"   %*\\r
-ENDLOCAL\\r
-EXIT /b %errorlevel%\\r
+GOTO start\\r
 :find_dp0\\r
 SET dp0=%~dp0\\r
 EXIT /b\\r
+:start\\r
+SETLOCAL\\r
+CALL :find_dp0\\r
+"%dp0%\\"   %*\\r
 
 `
 
@@ -460,14 +460,14 @@ exit $?
 
 exports[`test/basic.js TAP no shebang > cmd 1`] = `
 @ECHO off\\r
-SETLOCAL\\r
-CALL :find_dp0\\r
-"%dp0%\\from.exe"   %*\\r
-ENDLOCAL\\r
-EXIT /b %errorlevel%\\r
+GOTO start\\r
 :find_dp0\\r
 SET dp0=%~dp0\\r
 EXIT /b\\r
+:start\\r
+SETLOCAL\\r
+CALL :find_dp0\\r
+"%dp0%\\from.exe"   %*\\r
 
 `
 


### PR DESCRIPTION
This fixes [npm issue #969](https://github.com/npm/cli/issues/969)
(One test still fails, but it also fails without these changes.)