### PR TITLE
Powershell - Windows - Fix resolving commands that do not have an exe file

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,22 +152,12 @@ const writeShim_ = (from, to, prog, args, variables) => {
 
   // #!/usr/bin/env pwsh
   // $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-  // $exe=""
-  // if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
-  //   # Fix case when both the Windows and Linux builds of Node
-  //   # are installed in the same directory
-  //   $exe=".exe"
-  // }
   //
-  // $nodepath=""
-  // if (($exe -ne "") -and (Test-Path ("$basedir/node" + $exe))) {
-  //   $nodepath="$basedir/node" + $exe
+  // $nodepath="node"
+  // if ($IsWindows -and (Test-Path ("$basedir/node" + ".exe"))) {
+  //   $nodepath="$basedir/node" + ".exe"
   // } elseif (Test-Path "$basedir/node") {
   //   $nodepath="$basedir/node"
-  // } elseif (($exe -ne "") -and (Get-Command ("node" + $exe) -errorAction SilentlyContinue)) {
-  //   $nodepath="node" + $exe
-  // } else {
-  //   $nodepath="node"
   // }
   //
   // # Support pipeline input
@@ -179,28 +169,17 @@ const writeShim_ = (from, to, prog, args, variables) => {
   // exit $LASTEXITCODE
   let pwsh = '#!/usr/bin/env pwsh\n'
            + '$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent\n'
-           + '$exe=""\n'
-           + 'if ($PSVersionTable.PSVersion -lt \"6.0\" -or $IsWindows) {\n'
-           + '  # Fix case when both the Windows and Linux builds of Node\n'
-           + '  # are installed in the same directory\n'
-           + '  $exe=".exe"\n'
-           + '}\n'
            + '\n'
-           + `$nodepath=""\n`
+           + `$nodepath=${pwshProg}\n`
   if (pwshLongProg) {
     pwsh = pwsh
-         + `if (($exe -ne "") -and (Test-Path (${pwshLongProg} + $exe))) {\n`
-         + `  $nodepath=${pwshLongProg} + $exe\n`
+         + `if ($IsWindows -and (Test-Path (${pwshLongProg} + ".exe"))) {\n`
+         + `  $nodepath=${pwshLongProg} + ".exe"\n`
          + `} elseif (Test-Path ${pwshLongProg}) {\n`
          + `  $nodepath=${pwshLongProg}\n`
-         + '} else'
+         + `}\n`;
   }
   pwsh = pwsh
-        + `if (($exe -ne "") -and (Get-Command (${pwshProg} + $exe) -errorAction SilentlyContinue)) {\n`
-        + `  $nodepath=${pwshProg} + $exe\n`
-        + `} else {\n`
-        + `  $nodepath=${pwshProg}\n`
-        + `}\n`
         + '\n'
         + '# Support pipeline input\n'
         + 'if ($MyInvocation.ExpectingInput) {\n'

--- a/tap-snapshots/test-basic.js-TAP.test.js
+++ b/tap-snapshots/test-basic.js-TAP.test.js
@@ -29,22 +29,12 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\from
 exports[`test/basic.js TAP env shebang > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-$exe=""
-if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
-  # Fix case when both the Windows and Linux builds of Node
-  # are installed in the same directory
-  $exe=".exe"
-}
 
-$nodepath=""
-if (($exe -ne "") -and (Test-Path ("$basedir/node" + $exe))) {
-  $nodepath="$basedir/node" + $exe
+$nodepath="node"
+if ($IsWindows -and (Test-Path ("$basedir/node" + ".exe"))) {
+  $nodepath="$basedir/node" + ".exe"
 } elseif (Test-Path "$basedir/node") {
   $nodepath="$basedir/node"
-} elseif (($exe -ne "") -and (Get-Command ("node" + $exe) -errorAction SilentlyContinue)) {
-  $nodepath="node" + $exe
-} else {
-  $nodepath="node"
 }
 
 # Support pipeline input
@@ -97,22 +87,12 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" --expose_gc "
 exports[`test/basic.js TAP env shebang with args > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-$exe=""
-if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
-  # Fix case when both the Windows and Linux builds of Node
-  # are installed in the same directory
-  $exe=".exe"
-}
 
-$nodepath=""
-if (($exe -ne "") -and (Test-Path ("$basedir/node" + $exe))) {
-  $nodepath="$basedir/node" + $exe
+$nodepath="node"
+if ($IsWindows -and (Test-Path ("$basedir/node" + ".exe"))) {
+  $nodepath="$basedir/node" + ".exe"
 } elseif (Test-Path "$basedir/node") {
   $nodepath="$basedir/node"
-} elseif (($exe -ne "") -and (Get-Command ("node" + $exe) -errorAction SilentlyContinue)) {
-  $nodepath="node" + $exe
-} else {
-  $nodepath="node"
 }
 
 # Support pipeline input
@@ -166,22 +146,12 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\from
 exports[`test/basic.js TAP env shebang with variables > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-$exe=""
-if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
-  # Fix case when both the Windows and Linux builds of Node
-  # are installed in the same directory
-  $exe=".exe"
-}
 
-$nodepath=""
-if (($exe -ne "") -and (Test-Path ("$basedir/node" + $exe))) {
-  $nodepath="$basedir/node" + $exe
+$nodepath="node"
+if ($IsWindows -and (Test-Path ("$basedir/node" + ".exe"))) {
+  $nodepath="$basedir/node" + ".exe"
 } elseif (Test-Path "$basedir/node") {
   $nodepath="$basedir/node"
-} elseif (($exe -ne "") -and (Get-Command ("node" + $exe) -errorAction SilentlyContinue)) {
-  $nodepath="node" + $exe
-} else {
-  $nodepath="node"
 }
 
 # Support pipeline input
@@ -234,22 +204,12 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\from
 exports[`test/basic.js TAP explicit shebang > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-$exe=""
-if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
-  # Fix case when both the Windows and Linux builds of Node
-  # are installed in the same directory
-  $exe=".exe"
-}
 
-$nodepath=""
-if (($exe -ne "") -and (Test-Path ("$basedir//usr/bin/sh" + $exe))) {
-  $nodepath="$basedir//usr/bin/sh" + $exe
+$nodepath="/usr/bin/sh"
+if ($IsWindows -and (Test-Path ("$basedir//usr/bin/sh" + ".exe"))) {
+  $nodepath="$basedir//usr/bin/sh" + ".exe"
 } elseif (Test-Path "$basedir//usr/bin/sh") {
   $nodepath="$basedir//usr/bin/sh"
-} elseif (($exe -ne "") -and (Get-Command ("/usr/bin/sh" + $exe) -errorAction SilentlyContinue)) {
-  $nodepath="/usr/bin/sh" + $exe
-} else {
-  $nodepath="/usr/bin/sh"
 }
 
 # Support pipeline input
@@ -302,22 +262,12 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" -x "%dp0%\\fr
 exports[`test/basic.js TAP explicit shebang with args > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-$exe=""
-if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
-  # Fix case when both the Windows and Linux builds of Node
-  # are installed in the same directory
-  $exe=".exe"
-}
 
-$nodepath=""
-if (($exe -ne "") -and (Test-Path ("$basedir//usr/bin/sh" + $exe))) {
-  $nodepath="$basedir//usr/bin/sh" + $exe
+$nodepath="/usr/bin/sh"
+if ($IsWindows -and (Test-Path ("$basedir//usr/bin/sh" + ".exe"))) {
+  $nodepath="$basedir//usr/bin/sh" + ".exe"
 } elseif (Test-Path "$basedir//usr/bin/sh") {
   $nodepath="$basedir//usr/bin/sh"
-} elseif (($exe -ne "") -and (Get-Command ("/usr/bin/sh" + $exe) -errorAction SilentlyContinue)) {
-  $nodepath="/usr/bin/sh" + $exe
-} else {
-  $nodepath="/usr/bin/sh"
 }
 
 # Support pipeline input
@@ -362,19 +312,8 @@ CALL :find_dp0\\r
 exports[`test/basic.js TAP if exists (it does exist) > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-$exe=""
-if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
-  # Fix case when both the Windows and Linux builds of Node
-  # are installed in the same directory
-  $exe=".exe"
-}
 
-$nodepath=""
-if (($exe -ne "") -and (Get-Command ("$basedir/from.exe" + $exe) -errorAction SilentlyContinue)) {
-  $nodepath="$basedir/from.exe" + $exe
-} else {
-  $nodepath="$basedir/from.exe"
-}
+$nodepath="$basedir/from.exe"
 
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {
@@ -414,19 +353,8 @@ CALL :find_dp0\\r
 exports[`test/basic.js TAP just proceed if reading fails > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-$exe=""
-if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
-  # Fix case when both the Windows and Linux builds of Node
-  # are installed in the same directory
-  $exe=".exe"
-}
 
-$nodepath=""
-if (($exe -ne "") -and (Get-Command ("$basedir/" + $exe) -errorAction SilentlyContinue)) {
-  $nodepath="$basedir/" + $exe
-} else {
-  $nodepath="$basedir/"
-}
+$nodepath="$basedir/"
 
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {
@@ -466,19 +394,8 @@ CALL :find_dp0\\r
 exports[`test/basic.js TAP no shebang > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-$exe=""
-if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
-  # Fix case when both the Windows and Linux builds of Node
-  # are installed in the same directory
-  $exe=".exe"
-}
 
-$nodepath=""
-if (($exe -ne "") -and (Get-Command ("$basedir/from.exe" + $exe) -errorAction SilentlyContinue)) {
-  $nodepath="$basedir/from.exe" + $exe
-} else {
-  $nodepath="$basedir/from.exe"
-}
+$nodepath="$basedir/from.exe"
 
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {

--- a/tap-snapshots/test-basic.js-TAP.test.js
+++ b/tap-snapshots/test-basic.js-TAP.test.js
@@ -29,32 +29,31 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\from
 exports[`test/basic.js TAP env shebang > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-
 $exe=""
 if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
   # Fix case when both the Windows and Linux builds of Node
   # are installed in the same directory
   $exe=".exe"
 }
-$ret=0
-if (Test-Path "$basedir/node$exe") {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "$basedir/node$exe"  "$basedir/from.env" $args
-  } else {
-    & "$basedir/node$exe"  "$basedir/from.env" $args
-  }
-  $ret=$LASTEXITCODE
+
+$nodepath=""
+if (($exe -ne "") -and (Test-Path ("$basedir/node" + $exe))) {
+  $nodepath="$basedir/node" + $exe
+} elseif (Test-Path "$basedir/node") {
+  $nodepath="$basedir/node"
+} elseif (($exe -ne "") -and (Get-Command ("node" + $exe) -errorAction SilentlyContinue)) {
+  $nodepath="node" + $exe
 } else {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "node$exe"  "$basedir/from.env" $args
-  } else {
-    & "node$exe"  "$basedir/from.env" $args
-  }
-  $ret=$LASTEXITCODE
+  $nodepath="node"
 }
-exit $ret
+
+# Support pipeline input
+if ($MyInvocation.ExpectingInput) {
+  $input | & $nodepath  "$basedir/from.env" $args
+} else {
+  & $nodepath  "$basedir/from.env" $args
+}
+exit $LASTEXITCODE
 
 `
 
@@ -98,32 +97,31 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" --expose_gc "
 exports[`test/basic.js TAP env shebang with args > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-
 $exe=""
 if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
   # Fix case when both the Windows and Linux builds of Node
   # are installed in the same directory
   $exe=".exe"
 }
-$ret=0
-if (Test-Path "$basedir/node$exe") {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "$basedir/node$exe" --expose_gc "$basedir/from.env.args" $args
-  } else {
-    & "$basedir/node$exe" --expose_gc "$basedir/from.env.args" $args
-  }
-  $ret=$LASTEXITCODE
+
+$nodepath=""
+if (($exe -ne "") -and (Test-Path ("$basedir/node" + $exe))) {
+  $nodepath="$basedir/node" + $exe
+} elseif (Test-Path "$basedir/node") {
+  $nodepath="$basedir/node"
+} elseif (($exe -ne "") -and (Get-Command ("node" + $exe) -errorAction SilentlyContinue)) {
+  $nodepath="node" + $exe
 } else {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "node$exe" --expose_gc "$basedir/from.env.args" $args
-  } else {
-    & "node$exe" --expose_gc "$basedir/from.env.args" $args
-  }
-  $ret=$LASTEXITCODE
+  $nodepath="node"
 }
-exit $ret
+
+# Support pipeline input
+if ($MyInvocation.ExpectingInput) {
+  $input | & $nodepath --expose_gc "$basedir/from.env.args" $args
+} else {
+  & $nodepath --expose_gc "$basedir/from.env.args" $args
+}
+exit $LASTEXITCODE
 
 `
 
@@ -168,32 +166,31 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\from
 exports[`test/basic.js TAP env shebang with variables > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-
 $exe=""
 if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
   # Fix case when both the Windows and Linux builds of Node
   # are installed in the same directory
   $exe=".exe"
 }
-$ret=0
-if (Test-Path "$basedir/node$exe") {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "$basedir/node$exe"  "$basedir/from.env.variables" $args
-  } else {
-    & "$basedir/node$exe"  "$basedir/from.env.variables" $args
-  }
-  $ret=$LASTEXITCODE
+
+$nodepath=""
+if (($exe -ne "") -and (Test-Path ("$basedir/node" + $exe))) {
+  $nodepath="$basedir/node" + $exe
+} elseif (Test-Path "$basedir/node") {
+  $nodepath="$basedir/node"
+} elseif (($exe -ne "") -and (Get-Command ("node" + $exe) -errorAction SilentlyContinue)) {
+  $nodepath="node" + $exe
 } else {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "node$exe"  "$basedir/from.env.variables" $args
-  } else {
-    & "node$exe"  "$basedir/from.env.variables" $args
-  }
-  $ret=$LASTEXITCODE
+  $nodepath="node"
 }
-exit $ret
+
+# Support pipeline input
+if ($MyInvocation.ExpectingInput) {
+  $input | & $nodepath  "$basedir/from.env.variables" $args
+} else {
+  & $nodepath  "$basedir/from.env.variables" $args
+}
+exit $LASTEXITCODE
 
 `
 
@@ -237,32 +234,31 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\from
 exports[`test/basic.js TAP explicit shebang > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-
 $exe=""
 if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
   # Fix case when both the Windows and Linux builds of Node
   # are installed in the same directory
   $exe=".exe"
 }
-$ret=0
-if (Test-Path "$basedir//usr/bin/sh$exe") {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "$basedir//usr/bin/sh$exe"  "$basedir/from.sh" $args
-  } else {
-    & "$basedir//usr/bin/sh$exe"  "$basedir/from.sh" $args
-  }
-  $ret=$LASTEXITCODE
+
+$nodepath=""
+if (($exe -ne "") -and (Test-Path ("$basedir//usr/bin/sh" + $exe))) {
+  $nodepath="$basedir//usr/bin/sh" + $exe
+} elseif (Test-Path "$basedir//usr/bin/sh") {
+  $nodepath="$basedir//usr/bin/sh"
+} elseif (($exe -ne "") -and (Get-Command ("/usr/bin/sh" + $exe) -errorAction SilentlyContinue)) {
+  $nodepath="/usr/bin/sh" + $exe
 } else {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "/usr/bin/sh$exe"  "$basedir/from.sh" $args
-  } else {
-    & "/usr/bin/sh$exe"  "$basedir/from.sh" $args
-  }
-  $ret=$LASTEXITCODE
+  $nodepath="/usr/bin/sh"
 }
-exit $ret
+
+# Support pipeline input
+if ($MyInvocation.ExpectingInput) {
+  $input | & $nodepath  "$basedir/from.sh" $args
+} else {
+  & $nodepath  "$basedir/from.sh" $args
+}
+exit $LASTEXITCODE
 
 `
 
@@ -306,32 +302,31 @@ endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" -x "%dp0%\\fr
 exports[`test/basic.js TAP explicit shebang with args > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-
 $exe=""
 if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
   # Fix case when both the Windows and Linux builds of Node
   # are installed in the same directory
   $exe=".exe"
 }
-$ret=0
-if (Test-Path "$basedir//usr/bin/sh$exe") {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "$basedir//usr/bin/sh$exe" -x "$basedir/from.sh.args" $args
-  } else {
-    & "$basedir//usr/bin/sh$exe" -x "$basedir/from.sh.args" $args
-  }
-  $ret=$LASTEXITCODE
+
+$nodepath=""
+if (($exe -ne "") -and (Test-Path ("$basedir//usr/bin/sh" + $exe))) {
+  $nodepath="$basedir//usr/bin/sh" + $exe
+} elseif (Test-Path "$basedir//usr/bin/sh") {
+  $nodepath="$basedir//usr/bin/sh"
+} elseif (($exe -ne "") -and (Get-Command ("/usr/bin/sh" + $exe) -errorAction SilentlyContinue)) {
+  $nodepath="/usr/bin/sh" + $exe
 } else {
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & "/usr/bin/sh$exe" -x "$basedir/from.sh.args" $args
-  } else {
-    & "/usr/bin/sh$exe" -x "$basedir/from.sh.args" $args
-  }
-  $ret=$LASTEXITCODE
+  $nodepath="/usr/bin/sh"
 }
-exit $ret
+
+# Support pipeline input
+if ($MyInvocation.ExpectingInput) {
+  $input | & $nodepath -x "$basedir/from.sh.args" $args
+} else {
+  & $nodepath -x "$basedir/from.sh.args" $args
+}
+exit $LASTEXITCODE
 
 `
 
@@ -367,18 +362,25 @@ CALL :find_dp0\\r
 exports[`test/basic.js TAP if exists (it does exist) > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-
 $exe=""
 if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
   # Fix case when both the Windows and Linux builds of Node
   # are installed in the same directory
   $exe=".exe"
 }
+
+$nodepath=""
+if (($exe -ne "") -and (Get-Command ("$basedir/from.exe" + $exe) -errorAction SilentlyContinue)) {
+  $nodepath="$basedir/from.exe" + $exe
+} else {
+  $nodepath="$basedir/from.exe"
+}
+
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {
-  $input | & "$basedir/from.exe"   $args
+  $input | & $nodepath   $args
 } else {
-  & "$basedir/from.exe"   $args
+  & $nodepath   $args
 }
 exit $LASTEXITCODE
 
@@ -412,18 +414,25 @@ CALL :find_dp0\\r
 exports[`test/basic.js TAP just proceed if reading fails > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-
 $exe=""
 if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
   # Fix case when both the Windows and Linux builds of Node
   # are installed in the same directory
   $exe=".exe"
 }
+
+$nodepath=""
+if (($exe -ne "") -and (Get-Command ("$basedir/" + $exe) -errorAction SilentlyContinue)) {
+  $nodepath="$basedir/" + $exe
+} else {
+  $nodepath="$basedir/"
+}
+
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {
-  $input | & "$basedir/"   $args
+  $input | & $nodepath   $args
 } else {
-  & "$basedir/"   $args
+  & $nodepath   $args
 }
 exit $LASTEXITCODE
 
@@ -457,18 +466,25 @@ CALL :find_dp0\\r
 exports[`test/basic.js TAP no shebang > ps1 1`] = `
 #!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
-
 $exe=""
 if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
   # Fix case when both the Windows and Linux builds of Node
   # are installed in the same directory
   $exe=".exe"
 }
+
+$nodepath=""
+if (($exe -ne "") -and (Get-Command ("$basedir/from.exe" + $exe) -errorAction SilentlyContinue)) {
+  $nodepath="$basedir/from.exe" + $exe
+} else {
+  $nodepath="$basedir/from.exe"
+}
+
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {
-  $input | & "$basedir/from.exe"   $args
+  $input | & $nodepath   $args
 } else {
-  & "$basedir/from.exe"   $args
+  & $nodepath   $args
 }
 exit $LASTEXITCODE
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -50,7 +50,7 @@ test('fails if from doesnt exist', t => {
 test('fails if mkdir fails', t => {
   var from = path.resolve(fixtures, 'from.env')
   var to = path.resolve(fixtures, 'from.env/a/b/c')
-  return t.rejects(cmdShim(from, to), { code: /^(ENOTDIR|EEXIST)$/ })
+  return t.rejects(cmdShim(from, to), { code: /^(ENOTDIR|EEXIST|ENOENT)$/ })
 })
 
 test('fails if to is a dir', t => {


### PR DESCRIPTION
On Windows, the current powershell implementation assumes the command will resolve to a file with an `.exe` extension, but the file may be a `.bat`, `.ps1`, `.cmd`, or other type of executable.

- In 368348a, I have an implementation that does a check for the existence of a `.exe` extension and prefers that.
- After in d7c390b, I removed most of this since I don't believe it's necessary. I'm not sure why the exe check exists because windows will not execute a `node` file and it prefers executing `node.exe` when writing `node`. Also, why are Linux and Windows builds in the same directory (see what the comment said)? Perhaps this is too much of a breaking change or I am mistaken here, so let me know.

## References

Closes #51
