### PR TITLE
fix #45 set command quoted

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ const writeShim_ = (from, to, prog, args, variables) => {
   const head = '@ECHO off\r\n' +
     'GOTO start\r\n' +
     ':find_dp0\r\n' +
-    'SET dp0=%~dp0\r\n' +
+    'SET "dp0=%~dp0"\r\n' +
     'EXIT /b\r\n' +
     ':start\r\n' +
     'SETLOCAL\r\n' +

--- a/tap-snapshots/test-basic.js-TAP.test.js
+++ b/tap-snapshots/test-basic.js-TAP.test.js
@@ -9,7 +9,7 @@ exports[`test/basic.js TAP env shebang > cmd 1`] = `
 @ECHO off\\r
 GOTO start\\r
 :find_dp0\\r
-SET dp0=%~dp0\\r
+SET "dp0=%~dp0"\\r
 EXIT /b\\r
 :start\\r
 SETLOCAL\\r
@@ -78,7 +78,7 @@ exports[`test/basic.js TAP env shebang with args > cmd 1`] = `
 @ECHO off\\r
 GOTO start\\r
 :find_dp0\\r
-SET dp0=%~dp0\\r
+SET "dp0=%~dp0"\\r
 EXIT /b\\r
 :start\\r
 SETLOCAL\\r
@@ -147,7 +147,7 @@ exports[`test/basic.js TAP env shebang with variables > cmd 1`] = `
 @ECHO off\\r
 GOTO start\\r
 :find_dp0\\r
-SET dp0=%~dp0\\r
+SET "dp0=%~dp0"\\r
 EXIT /b\\r
 :start\\r
 SETLOCAL\\r
@@ -217,7 +217,7 @@ exports[`test/basic.js TAP explicit shebang > cmd 1`] = `
 @ECHO off\\r
 GOTO start\\r
 :find_dp0\\r
-SET dp0=%~dp0\\r
+SET "dp0=%~dp0"\\r
 EXIT /b\\r
 :start\\r
 SETLOCAL\\r
@@ -286,7 +286,7 @@ exports[`test/basic.js TAP explicit shebang with args > cmd 1`] = `
 @ECHO off\\r
 GOTO start\\r
 :find_dp0\\r
-SET dp0=%~dp0\\r
+SET "dp0=%~dp0"\\r
 EXIT /b\\r
 :start\\r
 SETLOCAL\\r
@@ -355,7 +355,7 @@ exports[`test/basic.js TAP if exists (it does exist) > cmd 1`] = `
 @ECHO off\\r
 GOTO start\\r
 :find_dp0\\r
-SET dp0=%~dp0\\r
+SET "dp0=%~dp0"\\r
 EXIT /b\\r
 :start\\r
 SETLOCAL\\r
@@ -400,7 +400,7 @@ exports[`test/basic.js TAP just proceed if reading fails > cmd 1`] = `
 @ECHO off\\r
 GOTO start\\r
 :find_dp0\\r
-SET dp0=%~dp0\\r
+SET "dp0=%~dp0"\\r
 EXIT /b\\r
 :start\\r
 SETLOCAL\\r
@@ -445,7 +445,7 @@ exports[`test/basic.js TAP no shebang > cmd 1`] = `
 @ECHO off\\r
 GOTO start\\r
 :find_dp0\\r
-SET dp0=%~dp0\\r
+SET "dp0=%~dp0"\\r
 EXIT /b\\r
 :start\\r
 SETLOCAL\\r


### PR DESCRIPTION
In `set` command parameter value read from %~p* parameter extension needed to be quoted to avoid special characters (like `&`)from path breaking command.
Current implementation:
```
SET dp0=%~dp0
```
evaluates to 
```
SET dp0=D:\CODE\dir-name-with & amp\vite-project\node_modules\.bin\
```
passing all characters after & as shell command (and failing):
```
"amp\vite-project\node_modules\.bin\" is not recognized as an internal or external command,
operable program or batch file.
```
Quoting set command parameters seems to fix this issue completely.


## References
Fixes #45
Closes #45