### PR TITLE
fix shebangExpr: ignore -S argument for /usr/bin/env

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ const {
 
 const { dirname, relative } = require('path')
 const toBatchSyntax = require('./to-batch-syntax')
-const shebangExpr = /^#!\s*(?:\/usr\/bin\/env\s*((?:[^ \t=]+=[^ \t=]+\s+)*))?([^ \t]+)(.*)$/
+const shebangExpr = /^#!\s*(?:\/usr\/bin\/env(?:\s+-S)?\s*((?:[^ \t=]+=[^ \t=]+\s+)*))?([^ \t]+)(.*)$/
 
 const cmdShimIfExists = (from, to) =>
   stat(from).then(() => cmdShim(from, to), () => {})


### PR DESCRIPTION
fixes https://github.com/pnpm/pnpm/issues/5575

related to https://github.com/pnpm/cmd-shim/pull/42

repro does not work for npm
because for this package, npm does not create a wrapper script

i guess these are only created for transitive dependencies in a deep node_modules folder
where we must set the `basedir`

```
cd $(mktemp -d)
npm init -y
npm i @suid/codemod prettier
npx @suid/codemod
```

npm

```
head -n5 node_modules/.bin/codemod 

#!/usr/bin/env -S node --no-warnings --experimental-specifier-resolution=node
import fixEsm from "./actions/fixEsm";
import mui2suid from "./actions/mui2suid";
import react2solid from "./actions/react2solid";
import suidImports from "./actions/suidImports";
```

pnpm

```
head -n5 node_modules/.bin/codemod 

#!/bin/sh
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")

case `uname` in
    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
```
