### PR TITLE
fix: don't assume cygpath is available

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,11 @@ const writeShim_ = (from, to, prog, args, variables) => {
   // basedir=`dirname "$0"`
   //
   // case `uname` in
-  //     *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+  //     *CYGWIN*|*MINGW*|*MSYS*)
+  //       if command -v cygpath > /dev/null 2>&1; then
+  //           basedir=`cygpath -w "$basedir"`
+  //       fi
+  //     ;;
   // esac
   //
   // if [ -x "$basedir/node.exe" ]; then
@@ -137,7 +141,11 @@ const writeShim_ = (from, to, prog, args, variables) => {
       + `basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")\n`
       + '\n'
       + 'case `uname` in\n'
-      + '    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;\n'
+      + '    *CYGWIN*|*MINGW*|*MSYS*)\n'
+      + '        if command -v cygpath > /dev/null 2>&1; then\n'
+      + '            basedir=`cygpath -w "$basedir"`\n'
+      + '        fi\n'
+      + '    ;;\n'
       + 'esac\n'
       + '\n'
 

--- a/tap-snapshots/test/basic.js.test.cjs
+++ b/tap-snapshots/test/basic.js.test.cjs
@@ -63,7 +63,11 @@ exports[`test/basic.js TAP env shebang > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -132,7 +136,11 @@ exports[`test/basic.js TAP env shebang with args > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -202,7 +210,11 @@ exports[`test/basic.js TAP env shebang with variables > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -271,7 +283,11 @@ exports[`test/basic.js TAP explicit shebang > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -340,7 +356,11 @@ exports[`test/basic.js TAP explicit shebang with args > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -389,7 +409,11 @@ exports[`test/basic.js TAP if exists (it does exist) > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 exec "$basedir/from.exe"   "$@"
@@ -434,7 +458,11 @@ exports[`test/basic.js TAP just proceed if reading fails > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 exec "$basedir/"   "$@"
@@ -501,7 +529,11 @@ exports[`test/basic.js TAP multiple variables > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -550,7 +582,11 @@ exports[`test/basic.js TAP no shebang > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 exec "$basedir/from.exe"   "$@"
@@ -615,7 +651,11 @@ exports[`test/basic.js TAP shebang with env -S > shell 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Fixes "cygpath command not found"

## References
There are over 1000 bugs on github with "cygpath command not found"

And I am guessing a large part of these is simply because this script generator assumes cygpath is installed.
