### PR TITLE
fix: support running sh shim from wsl

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,13 +60,14 @@ const writeShim = (from, to) =>
 
 const writeShim_ = (from, to, prog, args, variables) => {
   let shTarget = relative(dirname(to), from)
+  shTarget = shTarget.split('\\').join('/')
   let target = shTarget.split('/').join('\\')
+  let pwshTarget = shTarget
   let longProg
   let shProg = prog && prog.split('\\').join('/')
   let shLongProg
   let pwshProg = shProg && `"${shProg}$exe"`
   let pwshLongProg
-  shTarget = shTarget.split('\\').join('/')
   args = args || ''
   variables = variables || ''
   if (!prog) {
@@ -76,12 +77,14 @@ const writeShim_ = (from, to, prog, args, variables) => {
     args = ''
     target = ''
     shTarget = ''
+    pwshTarget = ''
   } else {
     longProg = `"%dp0%\\${prog}.exe"`
     shLongProg = `"$basedir/${prog}"`
     pwshLongProg = `"$basedir/${prog}$exe"`
     target = `"%dp0%\\${target}"`
-    shTarget = `"$basedir/${shTarget}"`
+    shTarget = `"$basedir_win/${shTarget}"`
+    pwshTarget = `"$basedir/${pwshTarget}"`
   }
 
   // Subroutine trick to fix https://github.com/npm/cmd-shim/issues/10
@@ -97,7 +100,6 @@ const writeShim_ = (from, to, prog, args, variables) => {
 
   let cmd
   if (longProg) {
-    shLongProg = shLongProg.trim()
     args = args.trim()
     const variablesBatch = toBatchSyntax.convertToSetCommands(variables)
     cmd = head
@@ -119,43 +121,77 @@ const writeShim_ = (from, to, prog, args, variables) => {
   }
 
   // #!/bin/sh
-  // basedir=`dirname "$0"`
+  // basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+  // basedir_win="$basedir"
   //
-  // case `uname` in
-  //     *CYGWIN*|*MINGW*|*MSYS*)
-  //       if command -v cygpath > /dev/null 2>&1; then
-  //           basedir=`cygpath -w "$basedir"`
+  // case `uname -a` in
+  //   *CYGWIN*|*MINGW*|*MSYS*)
+  //     if command -v cygpath > /dev/null 2>&1; then
+  //       basedir_win=`cygpath -w "$basedir"`
+  //     fi
+  //   ;;
+  //   *WSL2*)
+  //     if command -v wslpath > /dev/null 2>&1; then
+  //       basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+  //       if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+  //         echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+  //         exit 1
   //       fi
-  //     ;;
+  //     fi
+  //   ;;
   // esac
   //
-  // if [ -x "$basedir/node.exe" ]; then
-  //   exec "$basedir/node.exe" "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
-  // else
-  //   exec node "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
+  // PROG_EXE="$basedir/node.exe"
+  // if ! [ -x "$PROG_EXE" ]; then
+  //   PROG_EXE="$basedir/node"
+  //   if ! [ -x "$PROG_EXE" ]; then
+  //     PROG_EXE=node
+  //     if ! [ -x "$PROG_EXE" ]; then
+  //       PROG_EXE=node.exe
+  //     fi
+  //   fi
   // fi
+  //
+  // exec "$PROG_EXE"  "$basedir_win/node_modules/npm/bin/npm-cli.js" "$@"
 
   let sh = '#!/bin/sh\n'
 
   sh = sh
       + `basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")\n`
+      + 'basedir_win="$basedir"\n'
       + '\n'
-      + 'case `uname` in\n'
-      + '    *CYGWIN*|*MINGW*|*MSYS*)\n'
-      + '        if command -v cygpath > /dev/null 2>&1; then\n'
-      + '            basedir=`cygpath -w "$basedir"`\n'
-      + '        fi\n'
-      + '    ;;\n'
+      + 'case `uname -a` in\n'
+      + '  *CYGWIN*|*MINGW*|*MSYS*)\n'
+      + '    if command -v cygpath > /dev/null 2>&1; then\n'
+      + '      basedir_win=`cygpath -w "$basedir"`\n'
+      + '    fi\n'
+      + '  ;;\n'
+      + '  *WSL2*)\n'
+      + '    if command -v wslpath > /dev/null 2>&1; then\n'
+      + '      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"\n'
+      + '      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then\n'
+      + '        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2\n'
+      + '        exit 1\n'
+      + '      fi\n'
+      + '    fi\n'
+      + '  ;;\n'
       + 'esac\n'
       + '\n'
 
   if (shLongProg) {
     sh = sh
-       + `if [ -x ${shLongProg} ]; then\n`
-       + `  exec ${variables}${shLongProg} ${args} ${shTarget} "$@"\n`
-       + 'else \n'
-       + `  exec ${variables}${shProg} ${args} ${shTarget} "$@"\n`
+       + `PROG_EXE=${shLongProg.replace(/"$/, '.exe"')}\n`
+       + 'if ! [ -x "$PROG_EXE" ]; then\n'
+       + `  PROG_EXE=${shLongProg}\n`
+       + '  if ! [ -x "$PROG_EXE" ]; then\n'
+       + `    PROG_EXE=${shProg}\n`
+       + '    if ! [ -x "$PROG_EXE" ]; then\n'
+       + `      PROG_EXE=${shProg}.exe\n`
+       + '    fi\n'
+       + '  fi\n'
        + 'fi\n'
+       + '\n'
+       + `exec ${variables}"$PROG_EXE" ${args} ${shTarget} "$@"\n`
   } else {
     sh = sh
        + `exec ${shProg} ${args} ${shTarget} "$@"\n`
@@ -198,23 +234,23 @@ const writeShim_ = (from, to, prog, args, variables) => {
            + '  # are installed in the same directory\n'
            + '  $exe=".exe"\n'
            + '}\n'
-  if (shLongProg) {
+  if (pwshLongProg) {
     pwsh = pwsh
          + '$ret=0\n'
          + `if (Test-Path ${pwshLongProg}) {\n`
          + '  # Support pipeline input\n'
          + '  if ($MyInvocation.ExpectingInput) {\n'
-         + `    $input | & ${pwshLongProg} ${args} ${shTarget} $args\n`
+         + `    $input | & ${pwshLongProg} ${args} ${pwshTarget} $args\n`
          + '  } else {\n'
-         + `    & ${pwshLongProg} ${args} ${shTarget} $args\n`
+         + `    & ${pwshLongProg} ${args} ${pwshTarget} $args\n`
          + '  }\n'
          + '  $ret=$LASTEXITCODE\n'
          + '} else {\n'
          + '  # Support pipeline input\n'
          + '  if ($MyInvocation.ExpectingInput) {\n'
-         + `    $input | & ${pwshProg} ${args} ${shTarget} $args\n`
+         + `    $input | & ${pwshProg} ${args} ${pwshTarget} $args\n`
          + '  } else {\n'
-         + `    & ${pwshProg} ${args} ${shTarget} $args\n`
+         + `    & ${pwshProg} ${args} ${pwshTarget} $args\n`
          + '  }\n'
          + '  $ret=$LASTEXITCODE\n'
          + '}\n'
@@ -223,9 +259,9 @@ const writeShim_ = (from, to, prog, args, variables) => {
     pwsh = pwsh
          + '# Support pipeline input\n'
          + 'if ($MyInvocation.ExpectingInput) {\n'
-         + `  $input | & ${pwshProg} ${args} ${shTarget} $args\n`
+         + `  $input | & ${pwshProg} ${args} ${pwshTarget} $args\n`
          + '} else {\n'
-         + `  & ${pwshProg} ${args} ${shTarget} $args\n`
+         + `  & ${pwshProg} ${args} ${pwshTarget} $args\n`
          + '}\n'
          + 'exit $LASTEXITCODE\n'
   }

--- a/tap-snapshots/test/basic.js.test.cjs
+++ b/tap-snapshots/test/basic.js.test.cjs
@@ -61,20 +61,37 @@ exit $ret
 exports[`test/basic.js TAP env shebang > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/from.env" "$@"
-else 
-  exec node  "$basedir/from.env" "$@"
+PROG_EXE="$basedir/node.exe"
+if ! [ -x "$PROG_EXE" ]; then
+  PROG_EXE="$basedir/node"
+  if ! [ -x "$PROG_EXE" ]; then
+    PROG_EXE=node
+    if ! [ -x "$PROG_EXE" ]; then
+      PROG_EXE=node.exe
+    fi
+  fi
 fi
+
+exec "$PROG_EXE"  "$basedir_win/from.env" "$@"
 
 `
 
@@ -134,20 +151,37 @@ exit $ret
 exports[`test/basic.js TAP env shebang with args > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node" --expose_gc "$basedir/from.env.args" "$@"
-else 
-  exec node --expose_gc "$basedir/from.env.args" "$@"
+PROG_EXE="$basedir/node.exe"
+if ! [ -x "$PROG_EXE" ]; then
+  PROG_EXE="$basedir/node"
+  if ! [ -x "$PROG_EXE" ]; then
+    PROG_EXE=node
+    if ! [ -x "$PROG_EXE" ]; then
+      PROG_EXE=node.exe
+    fi
+  fi
 fi
+
+exec "$PROG_EXE" --expose_gc "$basedir_win/from.env.args" "$@"
 
 `
 
@@ -208,20 +242,37 @@ exit $ret
 exports[`test/basic.js TAP env shebang with variables > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
-  exec NODE_PATH=./lib:$NODE_PATH "$basedir/node"  "$basedir/from.env.variables" "$@"
-else 
-  exec NODE_PATH=./lib:$NODE_PATH node  "$basedir/from.env.variables" "$@"
+PROG_EXE="$basedir/node.exe"
+if ! [ -x "$PROG_EXE" ]; then
+  PROG_EXE="$basedir/node"
+  if ! [ -x "$PROG_EXE" ]; then
+    PROG_EXE=node
+    if ! [ -x "$PROG_EXE" ]; then
+      PROG_EXE=node.exe
+    fi
+  fi
 fi
+
+exec NODE_PATH=./lib:$NODE_PATH "$PROG_EXE"  "$basedir_win/from.env.variables" "$@"
 
 `
 
@@ -281,20 +332,37 @@ exit $ret
 exports[`test/basic.js TAP explicit shebang > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir//usr/bin/sh" ]; then
-  exec "$basedir//usr/bin/sh"  "$basedir/from.sh" "$@"
-else 
-  exec /usr/bin/sh  "$basedir/from.sh" "$@"
+PROG_EXE="$basedir//usr/bin/sh.exe"
+if ! [ -x "$PROG_EXE" ]; then
+  PROG_EXE="$basedir//usr/bin/sh"
+  if ! [ -x "$PROG_EXE" ]; then
+    PROG_EXE=/usr/bin/sh
+    if ! [ -x "$PROG_EXE" ]; then
+      PROG_EXE=/usr/bin/sh.exe
+    fi
+  fi
 fi
+
+exec "$PROG_EXE"  "$basedir_win/from.sh" "$@"
 
 `
 
@@ -354,20 +422,37 @@ exit $ret
 exports[`test/basic.js TAP explicit shebang with args > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir//usr/bin/sh" ]; then
-  exec "$basedir//usr/bin/sh" -x "$basedir/from.sh.args" "$@"
-else 
-  exec /usr/bin/sh -x "$basedir/from.sh.args" "$@"
+PROG_EXE="$basedir//usr/bin/sh.exe"
+if ! [ -x "$PROG_EXE" ]; then
+  PROG_EXE="$basedir//usr/bin/sh"
+  if ! [ -x "$PROG_EXE" ]; then
+    PROG_EXE=/usr/bin/sh
+    if ! [ -x "$PROG_EXE" ]; then
+      PROG_EXE=/usr/bin/sh.exe
+    fi
+  fi
 fi
+
+exec "$PROG_EXE" -x "$basedir_win/from.sh.args" "$@"
 
 `
 
@@ -407,13 +492,23 @@ exit $LASTEXITCODE
 exports[`test/basic.js TAP if exists (it does exist) > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
 exec "$basedir/from.exe"   "$@"
@@ -456,13 +551,23 @@ exit $LASTEXITCODE
 exports[`test/basic.js TAP just proceed if reading fails > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
 exec "$basedir/"   "$@"
@@ -527,20 +632,37 @@ exit $ret
 exports[`test/basic.js TAP multiple variables > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
-  exec key=value key2=value2 "$basedir/node" --flag-one --flag-two "$basedir/from.env.multiple.variables" "$@"
-else 
-  exec key=value key2=value2 node --flag-one --flag-two "$basedir/from.env.multiple.variables" "$@"
+PROG_EXE="$basedir/node.exe"
+if ! [ -x "$PROG_EXE" ]; then
+  PROG_EXE="$basedir/node"
+  if ! [ -x "$PROG_EXE" ]; then
+    PROG_EXE=node
+    if ! [ -x "$PROG_EXE" ]; then
+      PROG_EXE=node.exe
+    fi
+  fi
 fi
+
+exec key=value key2=value2 "$PROG_EXE" --flag-one --flag-two "$basedir_win/from.env.multiple.variables" "$@"
 
 `
 
@@ -580,13 +702,23 @@ exit $LASTEXITCODE
 exports[`test/basic.js TAP no shebang > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
 exec "$basedir/from.exe"   "$@"
@@ -649,19 +781,36 @@ exit $ret
 exports[`test/basic.js TAP shebang with env -S > shell 1`] = `
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir_win=\`cygpath -w "$basedir"\`
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        echo "Error: wslpath failed to convert path. WSL environment may be misconfigured." >&2
+        exit 1
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
-  exec "$basedir/node" --expose_gc "$basedir/from.env.S" "$@"
-else 
-  exec node --expose_gc "$basedir/from.env.S" "$@"
+PROG_EXE="$basedir/node.exe"
+if ! [ -x "$PROG_EXE" ]; then
+  PROG_EXE="$basedir/node"
+  if ! [ -x "$PROG_EXE" ]; then
+    PROG_EXE=node
+    if ! [ -x "$PROG_EXE" ]; then
+      PROG_EXE=node.exe
+    fi
+  fi
 fi
+
+exec "$PROG_EXE" --expose_gc "$basedir_win/from.env.S" "$@"
 
 `


### PR DESCRIPTION
<!-- What / Why -->
## What:
Support running sh shim from WSL.
<!-- Describe the request in detail. What it does and why it's being changed. -->
## Details:
- Previously, the generated sh shim called windows binary progs without `.exe` which works from msys/cygwin shells but not from wsl. Also, the the target passed to the windows binary prog as a parameter had a unix path on WSL.
- Now, we detect if we are in WSL, and check for the existence of an executable with and without `.exe`. We also use `wslpath` to convert parameter's path to a Windows path.

